### PR TITLE
Handle split frames properly; allow resizing from scratch

### DIFF
--- a/image+.el
+++ b/image+.el
@@ -171,7 +171,8 @@
 (defun imagex--maximize (image &optional maximum)
   "Adjust IMAGE to current frame."
   (let ((rect (let ((edges (window-inside-pixel-edges)))
-                (cons (nth 2 edges) (nth 3 edges)))))
+                (cons (- (nth 2 edges) (nth 0 edges))
+                      (- (nth 3 edges) (nth 1 edges))))))
     (imagex--fit-to-size image (car rect) (cdr rect) maximum)))
 
 (defun imagex--fit-to-size (image width height &optional max)
@@ -372,8 +373,8 @@ by 90 degrees."
       (when image
         (let ((prev-edges (plist-get (cdr image) 'imagex-auto-adjusted-edges))
               (curr-edges (window-edges)))
-          (when (and prev-edges
-                     (not (equal curr-edges prev-edges)))
+          (when (or (null prev-edges)
+                    (not (equal curr-edges prev-edges)))
             (let* ((orig (plist-get (cdr image) 'imagex-original-image))
                    (target (or orig image))
                    (new-image


### PR DESCRIPTION
Thanks for making this! Would you consider including this modification that will make it properly handle windows that are not the first window in the top left? I've also modified it so that it's easier to test (imagex--adjust-image-to-window) when there are no prev-edges yet. Thank you!
