### PR TITLE
workaround for emacs 26.1 changes.

### DIFF
--- a/image+.el
+++ b/image+.el
@@ -234,8 +234,8 @@
          (mr (+ (* 2 margin) (* 2 relief)))
          (w (+ (car pixels) mr))
          (h (+ (cdr pixels) mr))
-         (wr (/ width (ftruncate w)))
-         (hr (/ height (ftruncate h)))
+         (wr (/ width (ftruncate (float w))))
+         (hr (/ height (ftruncate (float h))))
          (magnification (apply 'min (delq nil (list wr hr max)))))
     (imagex--zoom image magnification)))
 


### PR DESCRIPTION
from emacs 26.1, ftruncate only accepts float as arguments. see https://github.com/emacs-mirror/emacs/blob/master/etc/NEWS.26#L1515